### PR TITLE
Live aj vramci video doplnku

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -21,6 +21,7 @@
   <news>
 [B]1.2.2[/B]
 - Live TV aj ako sucast video doplnku (pre ludi, ktorym blbne/nejde/nechce cez m3u a iptv simple), treba zapnut cez nastavenia, improvizovane EPG cez "plot"
+- moznost vypnut generovanie M3U - nezastavi service ako taky, len nebude nic generovat
 [B]1.2.1[/B]
 - Tuning loga stanic - moznosti nastavenia pre archiv, moznost pouzit loga zo stranky live, aj pre live playlist
 - Moznost obmedzenia vyberu zariadeni len na prehliadace (aby to neodhlasovalo z telefonu ci TV)

--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="plugin.video.sl" version="1.2.1" name="Skylink Live TV" provider-name="Sorien">
+<addon id="plugin.video.sl" version="1.2.2" name="Skylink Live TV" provider-name="Sorien">
 <requires>
   <import addon="xbmc.python" version="2.26.0"/>
   <import addon="script.module.requests" version="2.18.4"/>
@@ -19,6 +19,8 @@
   <forum>https://www.xbmc-kodi.cz/prispevek-skylink-livetv-addon-beta</forum>
   <source>https://github.com/Sorien/plugin.video.sl</source>
   <news>
+[B]1.2.2[/B]
+- Live TV aj ako sucast video doplnku (pre ludi, ktorym blbne/nejde/nechce cez m3u a iptv simple), treba zapnut cez nastavenia, improvizovane EPG cez "plot"
 [B]1.2.1[/B]
 - Tuning loga stanic - moznosti nastavenia pre archiv, moznost pouzit loga zo stranky live, aj pre live playlist
 - Moznost obmedzenia vyberu zariadeni len na prehliadace (aby to neodhlasovalo z telefonu ci TV)

--- a/live.py
+++ b/live.py
@@ -1,0 +1,100 @@
+# -*- coding: utf-8 -*-
+# Author: cache
+# Created on: 23.4.2019
+import sys
+import inputstreamhelper
+import logger
+import xbmcaddon
+import xbmcgui
+import xbmcplugin
+import urllib
+import datetime
+import utils
+
+_url = sys.argv[0]
+_handle = int(sys.argv[1])
+_addon = xbmcaddon.Addon()
+try:
+    _a_live_epg_next = int(xbmcplugin.getSetting(_handle, 'a_live_epg_next'))
+except:
+    logger.log.info('exception, 7 is ok')
+    _a_live_epg_next = 7
+
+EPG_GAP = 5 #gap for previous program
+
+def get_url(**kwargs):
+	return '{0}?{1}'.format(_url, urllib.urlencode(kwargs, 'utf-8'))
+
+def channels(sl):
+    channels = utils.call(sl, lambda: sl.channels(False))
+    xbmcplugin.setPluginCategory(_handle, _addon.getLocalizedString(30600))
+    if channels:
+        for channel in channels:
+            list_item = xbmcgui.ListItem(label=channel['title'])
+            list_item.setInfo('video', {'title': channel['title']}) #TODO - genre?
+            list_item.setArt({'thumb': utils.get_logo(channel['title'], sl)})
+            list_item.setProperty('IsPlayable','true')
+            link = get_url(live='play', lid=channel['id'], stationid=channel['stationid'], askpin=channel['pin'])
+            is_folder = False
+            xbmcplugin.addDirectoryItem(_handle, link, list_item, is_folder)
+    xbmcplugin.endOfDirectory(_handle)
+
+def play(sl, lid, stationid, askpin):
+    if askpin != 'False':
+        pin_ok = utils.ask_for_pin(sl)
+        if not pin_ok:
+            xbmcplugin.setResolvedUrl(_handle, False, xbmcgui.ListItem())
+            return
+
+    #improvised epg
+    def get_plot_line(start, title):
+        return '[B]' + start.strftime('%H:%M').decode('UTF-8') + '[/B] ' + title + '[CR]'
+
+    epg = utils.call(sl, lambda: sl.epg([{'stationid':stationid}], datetime.datetime.now(), 2))
+    if epg:
+        now = datetime.datetime.now()
+        plot = ''
+        last_program = None
+        items_left = _a_live_epg_next
+        for program in epg[0][stationid]:
+            start = datetime.datetime.fromtimestamp(program['start'])
+            show_item = start + datetime.timedelta(minutes=program['duration']) > now
+            if show_item:
+                if last_program is not None:
+                    last_start = datetime.datetime.fromtimestamp(last_program['start'])
+                    if last_start + datetime.timedelta(minutes=program['duration']+EPG_GAP) > now:
+                        plot = plot + get_plot_line(last_start,last_program['title'])
+                        items_left -= 1
+                        last_program = None
+                plot = plot + get_plot_line(start,program['title'])
+                items_left -= 1
+                if items_left == 0:
+                    break
+            else:
+                last_program = program
+        plot = plot[:-4]
+
+    info = {}
+
+    info = utils.call(sl, lambda: sl.channel_info(lid))
+
+    if info:
+        is_helper = inputstreamhelper.Helper(info['protocol'], drm=info['drm'])
+        if is_helper.check_inputstream():
+            playitem = xbmcgui.ListItem(path=info['path'])
+            if plot:
+                playitem.setInfo('video', {'plot':plot})
+            playitem.setProperty('inputstreamaddon', is_helper.inputstream_addon)
+            playitem.setProperty('inputstream.adaptive.manifest_type', info['protocol'])
+            playitem.setProperty('inputstream.adaptive.license_type', info['drm'])
+            playitem.setProperty('inputstream.adaptive.license_key', info['key'])
+            xbmcplugin.setResolvedUrl(_handle, True, playitem)
+
+def router(args, sl):
+    if args:
+        if args['live'][0] == 'play':
+            play(sl, args['lid'][0], args['stationid'][0], args['askpin'][0])
+        else:
+            channels(sl)
+    else:
+        channels(sl)

--- a/live.py
+++ b/live.py
@@ -62,11 +62,11 @@ def play(sl, lid, stationid, askpin):
             if show_item:
                 if last_program is not None:
                     last_start = datetime.datetime.fromtimestamp(last_program['start'])
-                    if last_start + datetime.timedelta(minutes=program['duration']+EPG_GAP) > now:
-                        plot = plot + get_plot_line(last_start,last_program['title'])
+                    if last_start + datetime.timedelta(minutes=last_program['duration']+EPG_GAP) > now:
+                        plot += + get_plot_line(last_start,last_program['title'])
                         items_left -= 1
                         last_program = None
-                plot = plot + get_plot_line(start,program['title'])
+                plot += get_plot_line(start,program['title'])
                 items_left -= 1
                 if items_left == 0:
                     break

--- a/main.py
+++ b/main.py
@@ -9,6 +9,7 @@ import xbmcgui
 import urlparse
 import xbmcplugin
 import replay
+import live
 import utils
 
 _id = int(sys.argv[1])
@@ -18,6 +19,7 @@ _user_name = xbmcplugin.getSetting(_id, 'username')
 _password = xbmcplugin.getSetting(_id, 'password')
 _provider = 'skylink.sk' if int(xbmcplugin.getSetting(_id, 'provider')) == 0 else 'skylink.cz'
 _pin_protected_content = 'false' != xbmcplugin.getSetting(_id, 'pin_protected_content')
+_a_show_live = 'false' != xbmcplugin.getSetting(_id, 'a_show_live')
 
 def play(channel_id, askpin):
     logger.log.info('play: ' + channel_id)
@@ -51,9 +53,13 @@ if __name__ == '__main__':
         play(str(args['id'][0]), str(args['askpin'][0]) if 'askpin' in args else 'False')
     elif 'replay' in args:
         replay.router(args, skylink.Skylink(_user_name, _password, _profile, _provider, _pin_protected_content))
+    elif 'live' in args:
+        live.router(args, skylink.Skylink(_user_name, _password, _profile, _provider, _pin_protected_content))
     else:
         xbmcplugin.setPluginCategory(_id, '')
         xbmcplugin.setContent(_id, 'videos')
         xbmcplugin.addDirectoryItem(_id, replay.get_url(replay='channels'), xbmcgui.ListItem(label=_addon.getLocalizedString(30600)), True)
+        if _a_show_live:
+            xbmcplugin.addDirectoryItem(_id, replay.get_url(live='channels'), xbmcgui.ListItem(label=_addon.getLocalizedString(30700)), True)
         xbmcplugin.endOfDirectory(_id)
 

--- a/replay.py
+++ b/replay.py
@@ -4,46 +4,21 @@
 import sys
 import inputstreamhelper
 import logger
-import requests
-import skylink
-import exports
-import xbmc
 import xbmcaddon
 import xbmcgui
-import urlparse
-import urllib
 import xbmcplugin
+import urllib
 import datetime
-import os
 import utils
 
 _url = sys.argv[0]
 _handle = int(sys.argv[1])
 _addon = xbmcaddon.Addon()
-_skylink_logos = 'false' != xbmcplugin.getSetting(_handle, 'a_sl_logos')
-if not _skylink_logos:
-    _remote_logos = '1' == xbmcplugin.getSetting(_handle, 'a_logos_location')
-    if _remote_logos:
-        _logos_base_url = xbmcplugin.getSetting(_handle, 'a_logos_base_url')
-        if not _logos_base_url.endswith("/"):
-            _logos_base_url = _logos_base_url + "/"
-    else:
-        _logos_folder = xbmcplugin.getSetting(_handle, 'a_logos_folder')
 
 REPLAY_GAP = 5 #gap after program ends til it shows in replay
 
 def get_url(**kwargs):
 	return '{0}?{1}'.format(_url, urllib.urlencode(kwargs, 'utf-8'))
-
-def get_logo(title, sl):
-    if _skylink_logos:
-        return sl.getUrl() + "/" + exports.logo_sl_location(title)
-    
-    if _remote_logos:
-        return _logos_base_url + exports.logo_id(title)
-
-    return os.path.join(_logos_folder, exports.logo_id(title))
-
 
 def channels(sl):
     channels = utils.call(sl, lambda: sl.channels(True))
@@ -52,7 +27,7 @@ def channels(sl):
         for channel in channels:
             list_item = xbmcgui.ListItem(label=channel['title'])
             list_item.setInfo('video', {'title': channel['title']}) #TODO - genre?
-            list_item.setArt({'thumb': get_logo(channel['title'], sl)})
+            list_item.setArt({'thumb': utils.get_logo(channel['title'], sl)})
             link = get_url(replay='days', stationid=channel['stationid'], channel=channel['title'], askpin=channel['pin'])
             is_folder = True
             xbmcplugin.addDirectoryItem(_handle, link, list_item, is_folder)

--- a/resources/language/Czech/strings.po
+++ b/resources/language/Czech/strings.po
@@ -59,6 +59,10 @@ msgctxt "#30204"
 msgid "Logo urls directly from Skylink Live TV site"
 msgstr "Url adresy pro loga stanic přímo ze stránky Skylink Live TV"
 
+msgctxt "#30205"
+msgid "Enabled M3U"
+msgstr "Generovat M3U"
+
 msgctxt "#30300"
 msgid "EPG"
 msgstr "EPG"
@@ -68,8 +72,8 @@ msgid "XMLTV"
 msgstr "XMLTV"
 
 msgctxt "#30302"
-msgid "Enabled"
-msgstr "EPG"
+msgid "Enabled EPG"
+msgstr "Generovat EPG"
 
 msgctxt "#30303"
 msgid "Directory of EPG file"

--- a/resources/language/Czech/strings.po
+++ b/resources/language/Czech/strings.po
@@ -111,6 +111,14 @@ msgctxt "#30356"
 msgid "Base url for logos"
 msgstr "Url stránky s logy"
 
+msgctxt "#30360"
+msgid "Live TV streams"
+msgstr "Zobrazit také živé vysílání"
+
+msgctxt "#30361"
+msgid "Next programs in improvised EPG"
+msgstr "Počet programů v improvizovaném EPG"
+
 msgctxt "#30401"
 msgid "Playlist created"
 msgstr "Playlist byl vytvořen"
@@ -202,6 +210,10 @@ msgstr "sobota"
 msgctxt "#30616"
 msgid "sunday"
 msgstr "neděle"
+
+msgctxt "#30700"
+msgid "Live TV"
+msgstr "Živé vysílání TV"
 
 msgctxt "#30900"
 msgid "Music"

--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -59,6 +59,10 @@ msgctxt "#30204"
 msgid "Logo urls directly from Skylink Live TV site"
 msgstr "Logo urls directly from Skylink Live TV site"
 
+msgctxt "#30205"
+msgid "Enabled M3U"
+msgstr "Enabled M3U"
+
 msgctxt "#30300"
 msgid "EPG"
 msgstr "EPG"
@@ -68,8 +72,8 @@ msgid "XMLTV"
 msgstr "XMLTV"
 
 msgctxt "#30302"
-msgid "Enabled"
-msgstr "Enabled"
+msgid "Enabled EPG"
+msgstr "Enabled EPG"
 
 msgctxt "#30303"
 msgid "Directory of EPG file"

--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -111,6 +111,14 @@ msgctxt "#30356"
 msgid "Base url for logos"
 msgstr "Base url for logos"
 
+msgctxt "#30360"
+msgid "Live TV streams"
+msgstr "Live TV streams"
+
+msgctxt "#30361"
+msgid "Next programs in improvised EPG"
+msgstr "Next programs in improvised EPG"
+
 msgctxt "#30401"
 msgid "M3U Playlist created"
 msgstr "M3U Playlist created"
@@ -202,6 +210,10 @@ msgstr "saturday"
 msgctxt "#30616"
 msgid "sunday"
 msgstr "sunday"
+
+msgctxt "#30700"
+msgid "Live TV"
+msgstr "Live TV"
 
 msgctxt "#30900"
 msgid "Music"

--- a/resources/language/Slovak/strings.po
+++ b/resources/language/Slovak/strings.po
@@ -111,6 +111,14 @@ msgctxt "#30356"
 msgid "Base url for logos"
 msgstr "Url stránky s logami"
 
+msgctxt "#30360"
+msgid "Live TV streams"
+msgstr "Zobraziť aj živé vysielanie"
+
+msgctxt "#30361"
+msgid "Next programs in improvised EPG"
+msgstr "Počet programov v improvizovanom EPG"
+
 msgctxt "#30401"
 msgid "M3U Playlist created"
 msgstr "M3U Playlist bol vytvorený"
@@ -202,6 +210,10 @@ msgstr "sobota"
 msgctxt "#30616"
 msgid "sunday"
 msgstr "nedeľa"
+
+msgctxt "#30700"
+msgid "Live TV"
+msgstr "Živé vysielanie TV"
 
 msgctxt "#30900"
 msgid "Music"

--- a/resources/language/Slovak/strings.po
+++ b/resources/language/Slovak/strings.po
@@ -59,6 +59,10 @@ msgctxt "#30204"
 msgid "Logo urls directly from Skylink Live TV site"
 msgstr "Url adresy pre logá staníc priamo zo stránky Skylink Live TV"
 
+msgctxt "#30205"
+msgid "Enabled M3U"
+msgstr "Generovať M3U"
+
 msgctxt "#30300"
 msgid "EPG"
 msgstr "EPG"
@@ -68,8 +72,8 @@ msgid "XMLTV"
 msgstr "XMLTV"
 
 msgctxt "#30302"
-msgid "Enabled"
-msgstr "Generovať"
+msgid "Enabled EPG"
+msgstr "Generovať EPG"
 
 msgctxt "#30303"
 msgid "Directory of EPG file"

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -12,9 +12,10 @@
     </category>
     <category label="30200">
         <setting label="30201" type="lsep"/>
-        <setting label="30202" type="folder" id="playlist_folder" default=""/>
-        <setting label="30203" type="text" id="playlist_file" default="playlist.m3u"/>
-        <setting label="30204" type="bool" id="sl_logos" default="false"/>
+        <setting label="30205" type="bool" id="playlist_generate" default="true" />
+        <setting label="30202" type="folder" id="playlist_folder" default="" enable="eq(-1,true)"/>
+        <setting label="30203" type="text" id="playlist_file" default="playlist.m3u" enable="eq(-2,true)"/>
+        <setting label="30204" type="bool" id="sl_logos" default="false" enable="eq(-3,true)"/>
     </category>
     <category label="30300">
         <setting label="30301" type="lsep"/>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -29,5 +29,7 @@
         <setting label="30352" type="enum" id="a_logos_location" lvalues="30353|30354" visible="eq(-1,false)" enable="eq(-1,false)"/>
         <setting label="30355" type="folder" id="a_logos_folder" default="" visible="eq(-2,false)+eq(-1,0)" enable="eq(-2,false)+eq(-1,0)"/>
         <setting label="30356" type="text" id="a_logos_base_url" default="https://koperfieldcz.github.io/skylink-livetv-logos/" visible="eq(-3,false)+eq(-2,1)" enable="eq(-3,false)+eq(-2,1)"/>
+        <setting label="30360" type="bool" id="a_show_live" default="false"/>
+        <setting label="30361" type="slider" id="a_live_epg_next" default="7" range="2,1,14" option="int" visible="eq(-1,true)"/>
     </category>
 </settings>

--- a/utils.py
+++ b/utils.py
@@ -1,14 +1,34 @@
 # -*- coding: utf-8 -*-
 # Author: cache
 # Created on: 15.4.2019
-
+import sys
 import xbmcaddon
 import xbmcgui
 import skylink
+import exports
 import requests
 import logger
+import os
 
 _addon = xbmcaddon.Addon()
+_skylink_logos = 'false' != _addon.getSetting('a_sl_logos')
+if not _skylink_logos:
+    _remote_logos = '1' == _addon.getSetting('a_logos_location')
+    if _remote_logos:
+        _logos_base_url = _addon.getSetting('a_logos_base_url')
+        if not _logos_base_url.endswith("/"):
+            _logos_base_url = _logos_base_url + "/"
+    else:
+        _logos_folder = _addon.getSetting('a_logos_folder')
+
+def get_logo(title, sl):
+    if _skylink_logos:
+        return sl.getUrl() + "/" + exports.logo_sl_location(title)
+    
+    if _remote_logos:
+        return _logos_base_url + exports.logo_id(title)
+
+    return os.path.join(_logos_folder, exports.logo_id(title))
 
 def strip_devices(devices):
     strip = _addon.getSetting('device_web_only') == 'true'


### PR DESCRIPTION
Dostal som poziadavku, ci by nebolo mozne pouzivat Live aj len z video doplnku (ako ma napr. rtvs plugin) bez generovania playlistu, ked to clovek pouziva len obcasne.. Tak som pridal moznost vypnut generovanie playlistu a zapnut Live aj cez video doplnok, "epg" pre najblizsie programy sa zobrazuje ako plot pri prehravani. Default ale ostava playlist zapnuty a Live pri archive vypnuty.