### PR TITLE
fix epg

### DIFF
--- a/exports.py
+++ b/exports.py
@@ -54,7 +54,7 @@ def create_epg(channels, epg, path, addon=None, url='https://livetv.skylink.sk/'
         for e in epg:
             for c in e:
                 for p in e[str(c)]:
-                    b = datetime.datetime.fromtimestamp(p['start'])
+                    b = datetime.datetime.utcfromtimestamp(p['start'])
                     e = b + datetime.timedelta(minutes=p['duration'])
                     file.write(u'<programme channel="%s" start="%s" stop="%s">\n' % (
                         c, b.strftime('%Y%m%d%H%M%S'), e.strftime('%Y%m%d%H%M%S')))


### PR DESCRIPTION
timestamp has to be in UTC

https://metacpan.org/pod/DateTime::Format::XMLTV

> All dates and times in this DTD follow the same format, loosely based on ISO 8601. They can be YYYYMMDDhhmmss or some initial substring, for example if you only know the year and month you can have YYYYMM. You can also append a timezone to the end; if no explicit timezone is given, UTC is assumed. Examples: 200007281733 BST, 200209, 19880523083000 +0300. (BST == +0100.)
