### PR TITLE
Zmena api url

### DIFF
--- a/live.py
+++ b/live.py
@@ -64,7 +64,7 @@ def channels(sl):
             plot = generate_plot([x for x in epg if stationid in x][0][stationid],4) if epg else u''
             list_item = xbmcgui.ListItem(label=channel['title'])
             list_item.setInfo('video', {'title': channel['title'], 'plot': plot})
-            list_item.setArt({'thumb': utils.get_logo(channel['title'])})
+            list_item.setArt({'thumb': utils.get_logo(channel['title'], sl._api_url)})
             list_item.setProperty('IsPlayable', 'true')
             link = get_url(live='play', lid=channel['id'], stationid=stationid, askpin=channel['pin'])
             is_folder = False

--- a/replay.py
+++ b/replay.py
@@ -28,7 +28,7 @@ def channels(sl):
         for channel in channels:
             list_item = xbmcgui.ListItem(label=channel['title'])
             list_item.setInfo('video', {'title': channel['title']})  # TODO - genre?
-            list_item.setArt({'thumb': utils.get_logo(channel['title'])})
+            list_item.setArt({'thumb': utils.get_logo(channel['title'], sl._api_url)})
             link = get_url(replay='days', stationid=channel['stationid'], channel=channel['title'],
                            askpin=channel['pin'])
             is_folder = True

--- a/skylink.py
+++ b/skylink.py
@@ -13,9 +13,9 @@ except ImportError:
     from urllib.parse import urlparse, unquote, parse_qs  # 2.7
 
 UA = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.98 Safari/537.36'
-M7_DOMAIN = 'm7cz.solocoo.tv'
-M7_API_WEB = 'https://' + M7_DOMAIN + "/"
-M7_API_URL = M7_API_WEB + 'm7cziphone/'
+#M7_DOMAIN = 'm7cz.solocoo.tv'
+#M7_API_WEB = 'https://' + M7_DOMAIN + "/"
+#M7_API_URL = M7_API_WEB + 'm7cziphone/'
 
 
 class SkylinkException(Exception):
@@ -61,6 +61,7 @@ class Skylink:
     _session.max_redirects = 3
     _data = SkylinkSessionData()
     _url = ''
+    _api_url = ''
     _show_pin_protected = True
 
     def __init__(self, username, password, storage_dir, provider='skylink.sk', show_pin_protected=True):
@@ -72,6 +73,7 @@ class Skylink:
         self._storage_path = storage_dir
         self._storage_file = os.path.join(self._storage_path, '%s.session' % username.lower())
         self._url = 'https://livetv.' + provider
+        self._api_url = self._url + '/m7cziphone/'
         self._show_pin_protected = show_pin_protected
         self._load_session()
 
@@ -120,7 +122,7 @@ class Skylink:
             else:
                 raise UserInvalidException()
 
-            resp = requests.post(M7_API_URL + 'challenge.aspx',
+            resp = requests.post(self._api_url + 'challenge.aspx', #M7_API_URL
                                  json={"autotype": "nl",
                                        "app": self._app,
                                        "prettyname": "Chrome",
@@ -134,7 +136,7 @@ class Skylink:
 
             if ('error' in data) and (data['error'] == 'toomany'):
                 if device != '':
-                    resp = requests.post(M7_API_URL + 'challenge.aspx?r=1',
+                    resp = requests.post(self._api_url + 'challenge.aspx?r=1', #M7_API_URL
                                          json={"autotype": "nl",
                                                "app": self._app,
                                                "prettyname": "Chrome",
@@ -161,7 +163,7 @@ class Skylink:
 
     def _login(self):
         if self._data.is_valid():
-            resp = self._session.post(M7_API_URL + 'login.aspx',
+            resp = self._session.post(self._api_url + 'login.aspx', #M7_API_URL
                                       data={'secret': self._data.id + "\t" + self._data.secret,
                                             'uid': self._data.uid, 'app': self._app},
                                       headers={'User-Agent': UA})
@@ -185,14 +187,16 @@ class Skylink:
         return self._session.request(method, url, **kwargs)
 
     def _get(self, params):
-        return self._request('GET', M7_API_URL + 'capi.aspx', params=params, allow_redirects=True,
-                             headers={'User-Agent': UA, 'Referer': self._url,
+        return self._request('GET', self._api_url + 'capi.aspx', params=params, allow_redirects=True, #M7_API_URL
+                             headers={'User-Agent': UA, 'Referer': self._url, 'Origin': self._url,
+                                      'Sec-Fetch-Mode': 'cors', 'Sec-Fetch-Site': 'same-origin',
                                       'Accept': 'application/json, text/javascript, */*; q=0.01'})
 
     def _post(self, params, data):
-        return self._request('POST', M7_API_URL + 'capi.aspx', params=params, data=data,
+        return self._request('POST', self._api_url + 'capi.aspx', params=params, data=data, #M7_API_URL
                              json=None,
-                             headers={'User-Agent': UA, 'Referer': self._url,
+                             headers={'User-Agent': UA, 'Referer': self._url, 'Origin': self._url,
+                                      'Sec-Fetch-Mode': 'cors', 'Sec-Fetch-Site': 'same-origin',
                                       'Accept': 'application/json, text/javascript, */*; q=0.01',
                                       'X-Requested-With': 'XMLHttpRequest'})
 
@@ -284,7 +288,7 @@ class Skylink:
                 if 'description' in data:
                     data['description'] = data['description'].strip()
                 if 'cover' in data:
-                    data['cover'] = M7_API_WEB + data['cover'].replace('satplusimages', 'satplusimages/447x251')
+                    data['cover'] = self._url + '/' + data['cover'].replace('satplusimages', 'satplusimages/447x251') #M7_API_WEB
                 data.update(times(data['locId']))
             return epg_info
 
@@ -323,9 +327,10 @@ class Skylink:
 
         stream = res.json()
 
-        mpd_headers = {'Origin': self._url, 'Referer': self._url, 'User-Agent': UA}
+        mpd_headers = {'Origin': self._url, 'Referer': self._url, 'User-Agent': UA, 
+                       'Sec-Fetch-Mode': 'cors', 'Sec-Fetch-Site': 'same-origin'}
         drm_la_headers = {'Origin': self._url, 'Referer': self._url, 'Content-Type': 'application/octet-stream',
-                          'User-Agent': UA}
+                          'User-Agent': UA, 'Sec-Fetch-Mode': 'cors', 'Sec-Fetch-Site': 'same-origin'}
 
         return {
             'protocol': 'mpd',

--- a/utils.py
+++ b/utils.py
@@ -21,9 +21,9 @@ if not _skylink_logos:
         _logos_folder = _addon.getSetting('a_logos_folder')
 
 
-def get_logo(title):
+def get_logo(title, api_url):
     if _skylink_logos:
-        return skylink.M7_API_WEB + exports.logo_sl_location(title)
+        return api_url + exports.logo_sl_location(title)
 
     if _remote_logos:
         return _logos_base_url + exports.logo_id(title)


### PR DESCRIPTION
Pri kontrole preco zas nejde skylink (widevine problem - https://github.com/emilsvennesson/script.module.inputstreamhelper/issues/59) som postrehol, ze uz sa na webe opat volaju skylink api url, nie solocoo.

Zatial ale funguju aj aktualne volania.