### PR TITLE
Updates and fixes

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -22,6 +22,7 @@
 - generovanie epg aj do minulosti pre catchup, default 0
 - blokovanie upravy skinu pre Matrix
 - umoznenie preskakovania prvych troch minut pri pouziti "prehraj odtialto" v klasickom archive, default true
+- kategorie v kniznici
 [B]1.7.0[/B]
 - podpora Kodi 19, vratane catchup, vdaka panda7789
 [B]1.6.7[/B]

--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="plugin.video.sl" version="1.7.0" name="Skylink Live TV" provider-name="Sorien, cache-sk">
+<addon id="plugin.video.sl" version="1.7.1" name="Skylink Live TV" provider-name="Sorien, cache-sk">
 <requires>
   <import addon="script.module.requests" version="2.18.4"/>
   <import addon="script.module.inputstreamhelper" version="0.3.3"/>
@@ -18,6 +18,12 @@
   <forum>https://www.xbmc-kodi.cz/prispevek-skylink-livetv-addon-beta</forum>
   <source>https://github.com/Sorien/plugin.video.sl</source>
   <news>
+[B]1.7.1[/B]
+- generovanie epg aj do minulosti pre catchup, default 0
+- blokovanie upravy skinu pre Matrix
+- umoznenie preskakovania prvych troch minut pri pouziti "prehraj odtialto" v klasickom archive, default true
+[B]1.7.0[/B]
+- podpora Kodi 19, vratane catchup, vdaka panda7789
 [B]1.6.7[/B]
 - fix generovania kategorie v EPG
 - fix url na nahlady relacii

--- a/exports.py
+++ b/exports.py
@@ -33,7 +33,7 @@ def create_m3u(channels, path, logo_url=None):
 
         for c in channels:
             catchup_url = u'plugin://plugin.video.sl/?stationid=%s&askpin=%s&catchup_id={catchup-id}' % (c['stationid'], c['pin'])
-            catchup = u'catchup-days="7" catchup-source="'+catchup_url+'"' if c['replayable'] else ''
+            catchup = u'catchup-days="7" catchup-type="default" catchup-source="'+catchup_url+'"' if c['replayable'] else ''
             file.write(u'#EXTINF:-1 tvg-id="%s" tvg-logo="%s" %s,%s\n' % (
                 c['stationid'],
                 logo_url + logo_sl_location(c['title']) if logo_url is not None else logo_id(c['title']),

--- a/library.py
+++ b/library.py
@@ -38,6 +38,12 @@ CATEGORIES = [
     {'msg':_addon.getLocalizedString(30824), 'code':'History', 'pin':False},
     {'msg':_addon.getLocalizedString(30825), 'code':'Music', 'pin':False},
     {'msg':_addon.getLocalizedString(30826), 'code':'Sport', 'pin':False},
+    {'msg':_addon.getLocalizedString(30829), 'code':'Culture', 'pin':False},
+    {'msg':_addon.getLocalizedString(30830), 'code':'People', 'pin':False},
+    {'msg':_addon.getLocalizedString(30831), 'code':'Natural History', 'pin':False},
+    {'msg':_addon.getLocalizedString(30832), 'code':'Science', 'pin':False},
+    {'msg':_addon.getLocalizedString(30833), 'code':'Cars & Motors', 'pin':False},
+    {'msg':_addon.getLocalizedString(30834), 'code':'Technology', 'pin':False},
     {'msg':_addon.getLocalizedString(30827), 'code':'Other', 'pin':False},
     {'msg':_addon.getLocalizedString(30828), 'code':'Erotic', 'pin':True}
 ]

--- a/main.py
+++ b/main.py
@@ -68,7 +68,7 @@ def locId_from_time(sl, stationid, utc):
                 return program['locId']
 
 
-def play_archive(station_id, utc, askpin):
+def play_archive_utc(station_id, utc, askpin):
     logger.log.info('play archive: ' + station_id + 'utc: ' + utc)
     sl = skylink.Skylink(_user_name, _password, _profile, _provider)
 

--- a/pisc.py
+++ b/pisc.py
@@ -38,5 +38,7 @@ def set_pisc():
         _pisc.setSetting('logoPathType','1')
         _pisc.setSetting('logoBaseUrl','')
         _pisc.setSetting('logoFromEpg','2')
+    
+    xbmcgui.Dialog().ok(_self.getAddonInfo('name'), _self.getLocalizedString(30395))
 
 set_pisc()

--- a/replay.py
+++ b/replay.py
@@ -157,7 +157,7 @@ def replay(sl, locId, duration, lastLocId):
             playitem.setProperty('inputstream.adaptive.manifest_type', info['protocol'])
             playitem.setProperty('inputstream.adaptive.license_type', info['drm'])
             playitem.setProperty('inputstream.adaptive.license_key', info['key'])
-            skipOffset = "true" == _addon.getSetting('a_skip_offset')
+            skipOffset = "true" == xbmcaddon.Addon().getSetting('a_skip_offset')
             if skipOffset:
                 lastPlayed = None
                 if os.path.isfile(REPLAY_LAST_PLAYED):

--- a/resources/language/Czech/strings.po
+++ b/resources/language/Czech/strings.po
@@ -410,3 +410,27 @@ msgstr "Ostatní"
 msgctxt "#30828"
 msgid "Erotic"
 msgstr "Erotický"
+
+msgctxt "#30829"
+msgid "Culture"
+msgstr "Kultúra"
+
+msgctxt "#30830"
+msgid "People"
+msgstr "Lidé"
+
+msgctxt "#30831"
+msgid "Natural History"
+msgstr "Přírodní vědy"
+
+msgctxt "#30832"
+msgid "Science"
+msgstr "Věda"
+
+msgctxt "#30833"
+msgid "Cars & Motors"
+msgstr "Auto Moto"
+
+msgctxt "#30834"
+msgid "Technology"
+msgstr "Technologie"

--- a/resources/language/Czech/strings.po
+++ b/resources/language/Czech/strings.po
@@ -87,6 +87,10 @@ msgctxt "#30305"
 msgid "Preload Days"
 msgstr "Počet dní"
 
+msgctxt "#30306"
+msgid "Preload Catchup Days"
+msgstr "Počet archivních dní"
+
 msgctxt "#30350"
 msgid "Archive"
 msgstr "Archiv"
@@ -114,6 +118,10 @@ msgstr "Adresář s logy"
 msgctxt "#30356"
 msgid "Base url for logos"
 msgstr "Url stránky s logy"
+
+msgctxt "#30357"
+msgid "Skip offset while Play from here"
+msgstr "Přeskočit začátek při Přehrát odsud"
 
 msgctxt "#30360"
 msgid "Live TV streams"
@@ -167,6 +175,10 @@ msgctxt "#30380"
 msgid "Failed to activate the new skin, do it manually, and then set it."
 msgstr "Nepodařilo se aktivovat nový vzhled, udělejte to manuálně a pak si ho nastavte."
 
+msgctxt "#30381"
+msgid "For Kodi 19 Matrix use catchup in PVR IPTV Simple Client"
+msgstr "Pro Kodi 19 Matrix použijte catchup v PVR IPTV Simple Client"
+
 msgctxt "#30390"
 msgid "PVR IPTV Simple Client"
 msgstr "PVR IPTV Simple Client"
@@ -186,6 +198,10 @@ msgstr "Nemáte zapnuté generování ani playlistu, ani EPG."
 msgctxt "#30394"
 msgid "It will now display a dialog with the necessary restart several times. Then restart Kodi.\nI also recommend deleting data in Settings / PVR and TV - General.\nOnly start after you have generated a playlist or epg!\nThis process is irreversible, continue?"
 msgstr "Nyní zobrazí několikrát po sobě dialog s nutným restartem. Poté restartujte Kodi.\nNásledně doporučuji i vymazat údaje v Nastavení / PVR a televize - Všeobecné.\nSpusťte až poté, co máte vygenerovaný playlist resp. epg!\nTento proces je nevratný, pokračovat?"
+
+msgctxt "#30395"
+msgid "PVR IPTV Simple Client was configured."
+msgstr "PVR IPTV Simple Client byl nastaven."
 
 msgctxt "#30401"
 msgid "Playlist created"

--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -410,3 +410,27 @@ msgstr "Other"
 msgctxt "#30828"
 msgid "Erotic"
 msgstr "Erotic"
+
+msgctxt "#30829"
+msgid "Culture"
+msgstr "Culture"
+
+msgctxt "#30830"
+msgid "People"
+msgstr "People"
+
+msgctxt "#30831"
+msgid "Natural History"
+msgstr "Natural History"
+
+msgctxt "#30832"
+msgid "Science"
+msgstr "Science"
+
+msgctxt "#30833"
+msgid "Cars & Motors"
+msgstr "Cars & Motors"
+
+msgctxt "#30834"
+msgid "Technology"
+msgstr "Technology"

--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -87,6 +87,10 @@ msgctxt "#30305"
 msgid "Preload Days"
 msgstr "Preload Days"
 
+msgctxt "#30306"
+msgid "Preload Catchup Days"
+msgstr "Preload Catchup Days"
+
 msgctxt "#30350"
 msgid "Archive"
 msgstr "Archive"
@@ -114,6 +118,10 @@ msgstr "Directory with logos"
 msgctxt "#30356"
 msgid "Base url for logos"
 msgstr "Base url for logos"
+
+msgctxt "#30357"
+msgid "Skip offset while Play from here"
+msgstr "Skip offset while Play from here"
 
 msgctxt "#30360"
 msgid "Live TV streams"
@@ -167,6 +175,10 @@ msgctxt "#30380"
 msgid "Failed to activate the new skin, do it manually, and then set it."
 msgstr "Failed to activate the new skin, do it manually, and then set it."
 
+msgctxt "#30381"
+msgid "For Kodi 19 Matrix use catchup in PVR IPTV Simple Client"
+msgstr "For Kodi 19 Matrix use catchup in PVR IPTV Simple Client"
+
 msgctxt "#30390"
 msgid "PVR IPTV Simple Client"
 msgstr "PVR IPTV Simple Client"
@@ -186,6 +198,10 @@ msgstr "You have neither generation of playlist nor EPG enabled."
 msgctxt "#30394"
 msgid "It will now display a dialog with the necessary restart several times. Then restart Kodi.\nI also recommend deleting data in Settings / PVR and TV - General.\nOnly start after you have generated a playlist or epg!\nThis process is irreversible, continue?"
 msgstr "It will now display a dialog with the necessary restart several times. Then restart Kodi.\nI also recommend deleting data in Settings / PVR and TV - General.\nOnly start after you have generated a playlist or epg!\nThis process is irreversible, continue?"
+
+msgctxt "#30395"
+msgid "PVR IPTV Simple Client was configured."
+msgstr "PVR IPTV Simple Client was configured."
 
 msgctxt "#30401"
 msgid "M3U Playlist created"

--- a/resources/language/Slovak/strings.po
+++ b/resources/language/Slovak/strings.po
@@ -410,3 +410,27 @@ msgstr "Ostatné"
 msgctxt "#30828"
 msgid "Erotic"
 msgstr "Erotický"
+
+msgctxt "#30829"
+msgid "Culture"
+msgstr "Kultúra"
+
+msgctxt "#30830"
+msgid "People"
+msgstr "Ľudia"
+
+msgctxt "#30831"
+msgid "Natural History"
+msgstr "Prírodné vedy"
+
+msgctxt "#30832"
+msgid "Science"
+msgstr "Veda"
+
+msgctxt "#30833"
+msgid "Cars & Motors"
+msgstr "Auto Moto"
+
+msgctxt "#30834"
+msgid "Technology"
+msgstr "Technológie"

--- a/resources/language/Slovak/strings.po
+++ b/resources/language/Slovak/strings.po
@@ -85,7 +85,11 @@ msgstr "Súbor"
 
 msgctxt "#30305"
 msgid "Preload Days"
-msgstr "Počet dni"
+msgstr "Počet dní"
+
+msgctxt "#30306"
+msgid "Preload Catchup Days"
+msgstr "Počet archívnych dní"
 
 msgctxt "#30350"
 msgid "Archive"
@@ -114,6 +118,10 @@ msgstr "Adresár s logami"
 msgctxt "#30356"
 msgid "Base url for logos"
 msgstr "Url stránky s logami"
+
+msgctxt "#30357"
+msgid "Skip offset while Play from here"
+msgstr "Preskočiť začiatok pri Prehrať odtiaľto"
 
 msgctxt "#30360"
 msgid "Live TV streams"
@@ -167,6 +175,10 @@ msgctxt "#30380"
 msgid "Failed to activate the new skin, do it manually, and then set it."
 msgstr "Nepodarilo sa aktivovať nový vzhľad, spravte to manuálne a potom si ho nastavte."
 
+msgctxt "#30381"
+msgid "For Kodi 19 Matrix use catchup in PVR IPTV Simple Client"
+msgstr "Pre Kodi 19 Matrix použite catchup v PVR IPTV Simple Client"
+
 msgctxt "#30390"
 msgid "PVR IPTV Simple Client"
 msgstr "PVR IPTV Simple Client"
@@ -186,6 +198,10 @@ msgstr "Nemáte zapnuté generovanie ani playlistu, ani EPG."
 msgctxt "#30394"
 msgid "It will now display a dialog with the necessary restart several times. Then restart Kodi.\nI also recommend deleting data in Settings / PVR and TV - General.\nOnly start after you have generated a playlist or epg!\nThis process is irreversible, continue?"
 msgstr "Teraz zobrazí niekoľko krát po sebe dialóg s nutným reštartom. Potom reštartujte Kodi.\nNásledne odporúčam aj vymazať údaje v Nastavenia / PVR a televízia - Všeobecné.\nSpustite až po tom, čo máte vygenerovaný playlist resp. epg!\nTento proces je nezvratný, pokračovať?"
+
+msgctxt "#30395"
+msgid "PVR IPTV Simple Client was configured."
+msgstr "PVR IPTV Simple Client bol nastavený."
 
 msgctxt "#30401"
 msgid "M3U Playlist created"

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -23,6 +23,7 @@
         <setting label="30303" type="folder" id="epp_folder" default="" enable="eq(-1,true)"/>
         <setting label="30304" type="text" id="epg_file" default="epg.xml" enable="eq(-2,true)"/>
         <setting label="30305" type="slider" id="epg_days" default="2" range="1,1,7" option="int" enable="eq(-3,true)"/>
+        <setting label="30306" type="slider" id="epg_days_catchup" default="0" range="1,0,7" option="int" enable="eq(-4,true)"/>
     </category>
     <category label="30350">
         <setting label="30350" type="lsep"/>
@@ -30,6 +31,7 @@
         <setting label="30352" type="enum" id="a_logos_location" lvalues="30353|30354" visible="eq(-1,false)" enable="eq(-1,false)"/>
         <setting label="30355" type="folder" id="a_logos_folder" default="" visible="eq(-2,false)+eq(-1,0)" enable="eq(-2,false)+eq(-1,0)"/>
         <setting label="30356" type="text" id="a_logos_base_url" default="https://koperfieldcz.github.io/skylink-livetv-logos/" visible="eq(-3,false)+eq(-2,1)" enable="eq(-3,false)+eq(-2,1)"/>
+        <setting label="30357" type="bool" id="a_skip_offset" default="true"/>
         <setting label="30360" type="bool" id="a_show_live" default="false"/>
         <setting label="30361" type="slider" id="a_live_epg_next" default="7" range="2,1,14" option="int" visible="eq(-1,true)"/>
     </category>

--- a/service.py
+++ b/service.py
@@ -92,10 +92,13 @@ class SkylinkMonitor(xbmc.Monitor):
         if _epg_generate:
             try:
                 days = int(self._addon.getSetting('epg_days'))
-                path = os.path.join(self._addon.getSetting('epp_folder'), self._addon.getSetting('epg_file'))
-                logger.log.info('Updating EPG [%d days from %s]' % (days, datetime.datetime.now()))
+                catchup_days = int(self._addon.getSetting('epg_days_catchup'))
                 today = datetime.datetime.now()
-                exports.create_epg(channels, sl.epg(channels, today, today + datetime.timedelta(days=days)), path)
+                epgFrom = today - datetime.timedelta(days=catchup_days) if catchup_days > 0 else today
+                epgTo = today + datetime.timedelta(days=days)
+                path = os.path.join(self._addon.getSetting('epp_folder'), self._addon.getSetting('epg_file'))
+                logger.log.info('Updating EPG [from %s to %s]' % (epgFrom, epgTo))
+                exports.create_epg(channels, sl.epg(channels, epgFrom, epgTo), path)
                 result = 2
             except IOError as e:
                 logger.log.error(str(e))

--- a/skins.py
+++ b/skins.py
@@ -194,4 +194,8 @@ def modify():
         xbmcgui.Dialog().ok(newName, __language__(30380))
         xbmc.executebuiltin("ActivateWindow(10040,addons://user/xbmc.gui.skin,return)")
 
-modify()
+python3 = sys.version_info[0] >= 3
+if python3:
+    xbmcgui.Dialog().ok("Kodi 19 Matrix", xbmcaddon.Addon(id='plugin.video.sl').getLocalizedString(30381))
+else:
+    modify()


### PR DESCRIPTION
- generovanie epg aj do minulosti pre catchup, default 0
- blokovanie upravy skinu pre Matrix
- umoznenie preskakovania prvych troch minut pri pouziti "prehraj odtialto" v klasickom archive (video addon), default true
- pridane kategorie v kniznici
- drobnosti

note - prezeral som livetv web, pouziva uz uplne nove api, aj kniznica, aj prehravanie, aj replay, aj restart, vsetko uz natahuje inak.. zrejme ma caka dost velka prerabka..