### PR TITLE
Python dependency in addon.xml

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon id="plugin.video.sl" version="1.7.1" name="Skylink Live TV" provider-name="Sorien, cache-sk">
 <requires>
+  <import addon="xbmc.python" version="2.26.0"/>
   <import addon="script.module.requests" version="2.18.4"/>
   <import addon="script.module.inputstreamhelper" version="0.3.3"/>
 </requires>


### PR DESCRIPTION
xbmc-kodi.cz repo uz rozdeluje medzi Leia a Matrix doplnkami na zaklade python dependency, takze Skylink doplnok "zmizol" z repa.

Bohuzial z oficialnej specifikacie vypadla podpora python 2/3 kompatibilnych doplnkov, takze sa musia koli Leia a Matrixu drzat dve branche.

Vraciam teda aspon zatial povodnu python dependency, nech sa to vrati do Leia repo.

Pre buducnost bude treba zivit dve branche - master pre Matrix s python 3.0.0 dependency a Leia branchu so starsou dependency.. 