### PR TITLE
Action (pipeline) na automaticky update Leia branch

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,24 @@
+name: Synchronize Leia branch
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  workflow_dispatch:
+
+jobs:
+  sync:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: Leia
+          fetch-depth: 0
+      - run: git config user.name github-actions
+      - run: git config user.email github-actions@github.com
+      - run: git pull origin master
+      - run: sed -i 's/import addon="xbmc.python" version="3.0.0"/import addon="xbmc.python" version="2.26.0"/' addon.xml
+      - run: git add -A
+      - run: git diff-index --quiet HEAD || git commit -m "addon.xml auto update for Leia"
+      - run: git push --force

--- a/addon.xml
+++ b/addon.xml
@@ -84,3 +84,4 @@
   </assets>
 </extension>
 </addon>
+

--- a/addon.xml
+++ b/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon id="plugin.video.sl" version="1.7.1" name="Skylink Live TV" provider-name="Sorien, cache-sk">
 <requires>
-  <import addon="xbmc.python" version="2.26.0"/>
+  <import addon="xbmc.python" version="3.0.0"/>
   <import addon="script.module.requests" version="2.18.4"/>
   <import addon="script.module.inputstreamhelper" version="0.3.3"/>
 </requires>

--- a/addon.xml
+++ b/addon.xml
@@ -84,4 +84,3 @@
   </assets>
 </extension>
 </addon>
-


### PR DESCRIPTION
Spravil som action skript, ktory by mal po kazdom push a pull requeste syncnut Leia branch s tym, ze prepise tu python dependency v addon.xml.

Ergo, moze sa (aspon zatial) nadalej drzat len master v py2/3 kompatibilite a v repe bude v oboch.

Nez sa to mergne, treba vytvorit branch "Leia", ak je toto riesenie OK.

Jediny problem je, ze sa tymto ale znefunkcni addon v povodnom cz/sk repe. Neviem presne ako im to funguje, do submodulov by sa mal dat pridat aj branch = Leia, ale neviem ci to "zeru" aj tie ich skripty..

Napodobne bude na tom cder, ale to uz nech si riesi dotycny..