### PR TITLE
Fix: Collections abstract base classes deprecated aliases

### DIFF
--- a/library.py
+++ b/library.py
@@ -8,7 +8,7 @@ import xbmcgui
 import xbmcplugin
 import urllib
 import utils
-from collections import Mapping
+from collections.abc import Mapping
 from skylink import StreamNotResolvedException
 
 _url = sys.argv[0]


### PR DESCRIPTION
In python 3.10, there are removed deprecated aliases which leads to error while trying to access library.
https://docs.python.org/3/whatsnew/3.10.html

"Remove deprecated aliases to [Collections Abstract Base Classes](https://docs.python.org/3/library/collections.abc.html#collections-abstract-base-classes) from the [collections](https://docs.python.org/3/library/collections.html#module-collections) module. (Contributed by Victor Stinner in [bpo-37324](https://bugs.python.org/issue?@action=redirect&bpo=37324).)"

Fix inspired by https://github.com/tensorflow/tensorboard/issues/5478 and https://github.com/html5lib/html5lib-python/pull/403.
Tested on Ubuntu 22.04 while trying to repair plugin installation, walked through logs and found and fixed this issue.